### PR TITLE
[2026/05/19]ApplicationConfigTestの追加と保存先ディレクトリの設定値化

### DIFF
--- a/src/main/java/com/imageconversion/ApplicationConfig.java
+++ b/src/main/java/com/imageconversion/ApplicationConfig.java
@@ -1,8 +1,33 @@
 package com.imageconversion;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
 /**
  * <p>共通の設定値を提供するクラス。</p>
  */
+@Configuration
 public class ApplicationConfig {
 
+	/**
+	 * <p>アップロード先ディレクトリ。</p>
+	 */
+	@Value("${app.upload.dir}")
+	private String uploadDir;
+	
+	/**
+	 * <p>アップロード先ディレクトリを取得する。</p>
+	 * 
+	 * @return アップロード先ディレクトリ
+	 */
+	public String getUploadDir() {
+		return uploadDir;
+	}
+	
+	public String toString() {
+		return ApplicationConfig.class.getName() 
+				+ "["
+					+ "uploadDir=" + uploadDir
+				+ "]";
+	}
 }

--- a/src/main/java/com/imageconversion/config/ServletConfig.java
+++ b/src/main/java/com/imageconversion/config/ServletConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.web.servlet.ServletRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.imageconversion.ApplicationConfig;
 import com.imageconversion.conversion.servlet.ChangeExtensionServlet;
 import com.imageconversion.conversion.servlet.GetExtensionServlet;
 import com.imageconversion.conversion.servlet.InputImageServlet;
@@ -76,9 +77,10 @@ public class ServletConfig {
     }
 
     @Bean
-    public ServletRegistrationBean<SaveImageServlet> saveImageServlet(MultipartConfigElement multipartConfigElement) {
+    public ServletRegistrationBean<SaveImageServlet> saveImageServlet(MultipartConfigElement multipartConfigElement,
+    		ApplicationConfig applicationConfig) {
     	ServletRegistrationBean<SaveImageServlet> registration = 
-    			new ServletRegistrationBean<>(new SaveImageServlet(), "/function/saveImage");
+    			new ServletRegistrationBean<>(new SaveImageServlet(applicationConfig.getUploadDir()), "/function/saveImage");
     	
     	registration.setMultipartConfig(multipartConfigElement);
         return registration;

--- a/src/main/java/com/imageconversion/conversion/servlet/SaveImageServlet.java
+++ b/src/main/java/com/imageconversion/conversion/servlet/SaveImageServlet.java
@@ -22,13 +22,23 @@ public class SaveImageServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 	
 	// 保存先のディレクトリパス
-	private String dirPath = "C:/Download/";
+	private String dirPath;
        
     /**
      * @see HttpServlet#HttpServlet()
      */
     public SaveImageServlet() {
         super();
+    }
+    
+    /**
+     * <p>保存先のディレクトリパスを指定してインスタンスを生成する。</p>
+     * 
+     * @param dirPath 保存先のディレクトリパス
+     */
+    public SaveImageServlet(String dirPath) {
+    	super();
+    	this.dirPath = dirPath;
     }
 
 	/**

--- a/src/test/java/com/imageconversion/ApplicationConfigTest.java
+++ b/src/test/java/com/imageconversion/ApplicationConfigTest.java
@@ -1,0 +1,33 @@
+package com.imageconversion;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
+
+/**
+ * <p>{@link ApplicationConfig}のテストクラス。</p>
+ */
+@SpringBootTest
+@ContextConfiguration(classes = ApplicationConfig.class)
+public class ApplicationConfigTest {
+
+	@Autowired
+	private ApplicationConfig config;
+
+	/**
+	 * <p>正常系のテスト。</p>
+	 */
+	@Test
+	public void toStringSuccess01() {
+
+		// 実行・検証
+		assertEquals(
+				"com.imageconversion.ApplicationConfig"
+				+ "[uploadDir=C:/Download/]"
+				, config.toString());
+	}
+
+}


### PR DESCRIPTION
- 変更内容
  - 保存先ディレクトリの設定値化を行いました。
  - 空だったApplicationConfigに設定値から保存先ディレクトリを取得できるようにしました。
  - ApplicationConfigTestを追加しました。

<!-- for GitHub Copilot review  rule-->
<!-- I want to review in Japanese. -->

<!--
あなたはアーキテクチャレベルのエンジニアです。
以下の観点でレビューを行ってください。

- 可読性: 変数名やコメントは適切か。他の人が読んだときに、処理内容を容易に理解できるか。
- 保守性: 将来、条件が変更になった場合、修正は容易か。ハードコーディングされている箇所はないか。
- 堅牢性: エラーが発生する可能性など、予期せぬ事態への備えはできているか。
-->
<!-- for GitHub Copilot review  rule-->

<!-- I want to review in Japanese. -->